### PR TITLE
Update to 0.10.1; don't hide pre/post script output

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.10.0" %}
-{% set sha256 = "e64c01c8d4f916c1d82706a7ecd0bdeffec179cfdbcbe05ef28ffbb814fab9d6" %}
+{% set version = "0.10.1" %}
+{% set sha256 = "974f05cc9e9fa5df87825bf72af07e76a5f93aa6a0fc3f74adb979756573cc8b" %}
 
 package:
     name: bqplot

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,3 +1,1 @@
-@echo off
-
-"%PREFIX%\Scripts\jupyter-nbextension.exe" enable bqplot --py --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-nbextension.exe" enable bqplot --py --sys-prefix && if errorlevel 1 exit 1

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,1 +1,3 @@
-"%PREFIX%\Scripts\jupyter-nbextension.exe" enable bqplot --py --sys-prefix && if errorlevel 1 exit 1
+@echo off
+
+"%PREFIX%\Scripts\jupyter-nbextension.exe" enable bqplot --py --sys-prefix >> "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/jupyter-nbextension" enable bqplot --py --sys-prefix
+"${PREFIX}/bin/jupyter-nbextension" enable bqplot --py --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/jupyter-nbextension" enable bqplot --py --sys-prefix > /dev/null 2>&1
+"${PREFIX}/bin/jupyter-nbextension" enable bqplot --py --sys-prefix

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,3 +1,1 @@
-@echo off
-
-"%PREFIX%\Scripts\jupyter-nbextension.exe" disable bqplot --py --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-nbextension.exe" disable bqplot --py --sys-prefix && if errorlevel 1 exit 1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,1 +1,3 @@
-"%PREFIX%\Scripts\jupyter-nbextension.exe" disable bqplot --py --sys-prefix && if errorlevel 1 exit 1
+@echo off
+
+"%PREFIX%\Scripts\jupyter-nbextension.exe" disable bqplot --py --sys-prefix >> "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/jupyter-nbextension" disable bqplot --py --sys-prefix
+"${PREFIX}/bin/jupyter-nbextension" disable bqplot --py --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/jupyter-nbextension" disable bqplot --py --sys-prefix > /dev/null 2>&1
+"${PREFIX}/bin/jupyter-nbextension" disable bqplot --py --sys-prefix


### PR DESCRIPTION
I'm changing to not hide the pre/post script output. I've had some experience with installation errors getting swallowed up in the redirection happening in pre/post scripts, which was frustrating to debug. A user should see error messages happening in installation, and I think confirmation of things like enabling/disabling are also important in diagnosing installation issues.

IIRC, the reasons for hiding output in pre/post scripts was anaconda convention, but IIRC anaconda packages do not allow pre/post scripts, so it is a moot point.