### PR TITLE
Require ipywidgets >= 7.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 
@@ -24,7 +24,7 @@ requirements:
     - pip
   run:
     - python  >=3.6
-    - ipywidgets >=7.5.0,<8.0
+    - ipywidgets >=7.6.0,<8.0
     - traitlets >=4.3.0,<6.0
     - traittypes >=0.0.6
     - numpy >=1.10.4


### PR DESCRIPTION
In some cases, `ipywidgets==7.5` might already be installed by default, for example on Binder with repo2docker.

This means a manual install of `jupyterlab_widgets` or `ipywidgets>=7.6` would still be required for `bqplot` to work out of the box in JupyterLab 3.0.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
